### PR TITLE
Update add_note_page.dart

### DIFF
--- a/lib/pages/add_note_page.dart
+++ b/lib/pages/add_note_page.dart
@@ -344,7 +344,7 @@ class _TodoTextFieldsState extends State<TodoTextFields> {
 
   @override
   void dispose() {
-    todoController.dispose();
+    todoController.clear();
     super.dispose();
   }
 


### PR DESCRIPTION
Using todo controller.clear() instead of TODO controller.dispose() which render the object not reusable for another Text field widget.